### PR TITLE
feature/#21-local-database-implementation

### DIFF
--- a/data/local/build.gradle.kts
+++ b/data/local/build.gradle.kts
@@ -44,6 +44,10 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
 
+    api(libs.androidx.room.runtime)
+    ksp(libs.androidx.room.compiler)
+    implementation(libs.androidx.room.ktx)
+
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 

--- a/data/local/src/main/java/es/mobiledev/data/local/AppRoomDatabase.kt
+++ b/data/local/src/main/java/es/mobiledev/data/local/AppRoomDatabase.kt
@@ -1,0 +1,28 @@
+package es.mobiledev.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import es.mobiledev.data.local.article.dao.ArticleDao
+import es.mobiledev.data.local.article.dbo.ArticleDbo
+
+@Database(
+    entities = [
+        ArticleDbo::class,
+    ],
+    version = DATABASE_VERSION,
+)
+abstract class AppRoomDatabase : RoomDatabase() {
+    abstract fun articleDao(): ArticleDao
+
+    companion object {
+        fun buildDatabase(context: Context): AppRoomDatabase =
+            Room
+                .databaseBuilder(
+                    context = context.applicationContext,
+                    klass = AppRoomDatabase::class.java,
+                    name = DATABASE_NAME,
+                ).build()
+    }
+}

--- a/data/local/src/main/java/es/mobiledev/data/local/RoomConstants.kt
+++ b/data/local/src/main/java/es/mobiledev/data/local/RoomConstants.kt
@@ -1,0 +1,4 @@
+package es.mobiledev.data.local
+
+internal const val DATABASE_NAME = "RoomDatabase.db"
+internal const val DATABASE_VERSION = 1

--- a/data/local/src/main/java/es/mobiledev/data/local/article/dao/ArticleDao.kt
+++ b/data/local/src/main/java/es/mobiledev/data/local/article/dao/ArticleDao.kt
@@ -1,12 +1,20 @@
 package es.mobiledev.data.local.article.dao
 
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import es.mobiledev.data.local.article.dbo.ArticleDbo
 
-// TODO: Add Room annotations when be to implement
+@Dao
 interface ArticleDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveFavoriteArticle(article: ArticleDbo)
 
+    @Delete
     suspend fun removeFavoriteArticle(article: ArticleDbo)
 
+    @Query("SELECT * FROM articles")
     suspend fun getFavoriteArticles(): List<ArticleDbo>
 }

--- a/data/local/src/main/java/es/mobiledev/data/local/article/datasource/ArticleLocalDataSourceImpl.kt
+++ b/data/local/src/main/java/es/mobiledev/data/local/article/datasource/ArticleLocalDataSourceImpl.kt
@@ -1,26 +1,19 @@
 package es.mobiledev.data.local.article.datasource
 
+import es.mobiledev.data.local.AppRoomDatabase
 import es.mobiledev.data.local.article.dao.toBo
 import es.mobiledev.data.local.article.dao.toDbo
-import es.mobiledev.data.local.article.dbo.ArticleDbo
 import es.mobiledev.data.source.article.ArticleLocalDataSource
 import es.mobiledev.domain.model.article.ArticleBo
 
-// TODO: Connect with Dao when implement Room
 class ArticleLocalDataSourceImpl(
-    // private val articleDao: ArticleDao
+    private val roomDatabase: AppRoomDatabase,
 ) : ArticleLocalDataSource {
-    val mockLocalDb = mutableListOf<ArticleDbo>()
+    private val articleDao = roomDatabase.articleDao()
 
-    override suspend fun saveFavoriteArticle(article: ArticleBo) =
-        // articleDao.saveFavoriteArticle(article.toDbo())
-        mockLocalDb.add(article.toDbo())
+    override suspend fun saveFavoriteArticle(article: ArticleBo) = articleDao.saveFavoriteArticle(article.toDbo())
 
-    override suspend fun removeFavoriteArticle(article: ArticleBo) =
-        // articleDao.removeFavoriteArticle(article.toDbo())
-        mockLocalDb.removeIf { it.id == article.id }
+    override suspend fun removeFavoriteArticle(article: ArticleBo) = articleDao.removeFavoriteArticle(article.toDbo())
 
-    override suspend fun getFavoriteArticles(): List<ArticleBo> =
-        // articleDao.getFavoriteArticles().map { it.toBo() }
-        mockLocalDb.map { it.toBo() }
+    override suspend fun getFavoriteArticles(): List<ArticleBo> = articleDao.getFavoriteArticles().map { it.toBo() }
 }

--- a/data/local/src/main/java/es/mobiledev/data/local/article/dbo/ArticleDbo.kt
+++ b/data/local/src/main/java/es/mobiledev/data/local/article/dbo/ArticleDbo.kt
@@ -1,8 +1,11 @@
 package es.mobiledev.data.local.article.dbo
 
-// TODO: Add Room annotations when be to implement
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "articles")
 data class ArticleDbo(
-    val id: Long,
+    @PrimaryKey val id: Long,
     val title: String,
     val imageUrl: String,
     val newsSite: String,

--- a/data/local/src/main/java/es/mobiledev/data/local/di/LocalModule.kt
+++ b/data/local/src/main/java/es/mobiledev/data/local/di/LocalModule.kt
@@ -1,9 +1,11 @@
 package es.mobiledev.data.local.di
 
+import android.app.Application
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import es.mobiledev.data.local.AppRoomDatabase
 import es.mobiledev.data.local.article.datasource.ArticleLocalDataSourceImpl
 import es.mobiledev.data.source.article.ArticleLocalDataSource
 import javax.inject.Singleton
@@ -13,5 +15,9 @@ import javax.inject.Singleton
 object LocalModule {
     @Provides
     @Singleton
-    fun articleLocalDataSourceProvider() = ArticleLocalDataSourceImpl() as ArticleLocalDataSource
+    fun appRoomDatabaseProvider(context: Application) = AppRoomDatabase.buildDatabase(context)
+
+    @Provides
+    @Singleton
+    fun articleLocalDataSourceProvider(roomDatabase: AppRoomDatabase) = ArticleLocalDataSourceImpl(roomDatabase) as ArticleLocalDataSource
 }

--- a/data/repository/src/main/java/es/mobiledev/data/repository/article/ArticleRepository.kt
+++ b/data/repository/src/main/java/es/mobiledev/data/repository/article/ArticleRepository.kt
@@ -18,7 +18,7 @@ class ArticleRepository(
 
     override suspend fun getFavoriteArticles(): Flow<List<ArticleBo>> = flowOf(local.getFavoriteArticles())
 
-    override suspend fun saveFavoriteArticle(articleBo: ArticleBo) = flowOf(local.saveFavoriteArticle(articleBo))
+    override suspend fun saveFavoriteArticle(articleBo: ArticleBo) = local.saveFavoriteArticle(articleBo)
 
-    override suspend fun removeFavoriteArticle(articleBo: ArticleBo) = flowOf(local.removeFavoriteArticle(articleBo))
+    override suspend fun removeFavoriteArticle(articleBo: ArticleBo) = local.removeFavoriteArticle(articleBo)
 }

--- a/data/source/src/main/java/es/mobiledev/data/source/article/ArticleLocalDataSource.kt
+++ b/data/source/src/main/java/es/mobiledev/data/source/article/ArticleLocalDataSource.kt
@@ -3,9 +3,9 @@ package es.mobiledev.data.source.article
 import es.mobiledev.domain.model.article.ArticleBo
 
 interface ArticleLocalDataSource {
-    suspend fun saveFavoriteArticle(article: ArticleBo): Boolean
+    suspend fun saveFavoriteArticle(article: ArticleBo)
 
-    suspend fun removeFavoriteArticle(article: ArticleBo): Boolean
+    suspend fun removeFavoriteArticle(article: ArticleBo)
 
     suspend fun getFavoriteArticles(): List<ArticleBo>
 }

--- a/domain/gateway/src/main/java/es/mobiledev/domain/gateway/article/ArticleGateway.kt
+++ b/domain/gateway/src/main/java/es/mobiledev/domain/gateway/article/ArticleGateway.kt
@@ -11,7 +11,7 @@ interface ArticleGateway {
 
     suspend fun getFavoriteArticles(): Flow<List<ArticleBo>>
 
-    suspend fun saveFavoriteArticle(articleBo: ArticleBo): Flow<Boolean>
+    suspend fun saveFavoriteArticle(articleBo: ArticleBo)
 
-    suspend fun removeFavoriteArticle(articleBo: ArticleBo): Flow<Boolean>
+    suspend fun removeFavoriteArticle(articleBo: ArticleBo)
 }

--- a/domain/useCase/src/main/java/es/mobiledev/domain/usecase/article/RemoveFavoriteArticleUseCase.kt
+++ b/domain/useCase/src/main/java/es/mobiledev/domain/usecase/article/RemoveFavoriteArticleUseCase.kt
@@ -2,12 +2,11 @@ package es.mobiledev.domain.usecase.article
 
 import es.mobiledev.domain.gateway.article.ArticleGateway
 import es.mobiledev.domain.model.article.ArticleBo
-import kotlinx.coroutines.flow.Flow
 
 interface RemoveFavoriteArticleUseCase {
     suspend operator fun invoke(
         article: ArticleBo
-    ): Flow<Boolean>
+    )
 }
 
 class RemoveFavoriteArticleUseCaseImpl(
@@ -15,5 +14,5 @@ class RemoveFavoriteArticleUseCaseImpl(
 ) : RemoveFavoriteArticleUseCase {
     override suspend fun invoke(
         article: ArticleBo
-    ): Flow<Boolean> = articleGateway.removeFavoriteArticle(article)
+    ) = articleGateway.removeFavoriteArticle(article)
 }

--- a/domain/useCase/src/main/java/es/mobiledev/domain/usecase/article/SaveFavoriteArticleUseCase.kt
+++ b/domain/useCase/src/main/java/es/mobiledev/domain/usecase/article/SaveFavoriteArticleUseCase.kt
@@ -2,12 +2,11 @@ package es.mobiledev.domain.usecase.article
 
 import es.mobiledev.domain.gateway.article.ArticleGateway
 import es.mobiledev.domain.model.article.ArticleBo
-import kotlinx.coroutines.flow.Flow
 
 interface SaveFavoriteArticleUseCase {
     suspend operator fun invoke(
         article: ArticleBo
-    ): Flow<Boolean>
+    )
 }
 
 class SaveFavoriteArticleUseCaseImpl(
@@ -15,5 +14,5 @@ class SaveFavoriteArticleUseCaseImpl(
 ) : SaveFavoriteArticleUseCase {
     override suspend fun invoke(
         article: ArticleBo
-    ): Flow<Boolean> = articleGateway.saveFavoriteArticle(article)
+    ) = articleGateway.saveFavoriteArticle(article)
 }

--- a/feature/home/src/main/java/es/mobiledev/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/java/es/mobiledev/feature/home/viewmodel/HomeViewModel.kt
@@ -73,29 +73,30 @@ class HomeViewModel
 
         private suspend fun getLastOpenTime() =
             getLastOpenTimeUseCase().collectLatest { lastOpenTime ->
+                // TODO: Pending to handle errors
                 Log.d("HomeViewModel", "Last open time: $lastOpenTime")
             }
 
         fun saveFavoriteArticle(article: ArticleBo) {
             viewModelScope.launch(Dispatchers.IO) {
-                saveFavoriteArticleUseCase(article = article).collectLatest { isSaved ->
-                    if (isSaved) {
-                        getFavoriteArticles()
-                    } else {
-                        Log.e("HomeViewModel", "Error saving favorite article")
-                    }
+                try {
+                    saveFavoriteArticleUseCase(article = article)
+                    getFavoriteArticles()
+                } catch (e: Exception) {
+                    // TODO: Pending to handle errors
+                    Log.e("HomeViewModel", "Error saving favorite article", e)
                 }
             }
         }
 
         fun removeFavoriteArticle(article: ArticleBo) {
             viewModelScope.launch(Dispatchers.IO) {
-                removeFavoriteArticleUseCase(article = article).collectLatest { isRemoved ->
-                    if (isRemoved) {
-                        getFavoriteArticles()
-                    } else {
-                        Log.e("HomeViewModel", "Error removing favorite article")
-                    }
+                try {
+                    removeFavoriteArticleUseCase(article = article)
+                    getFavoriteArticles()
+                } catch (e: Exception) {
+                    // TODO: Pending to handle errors
+                    Log.e("HomeViewModel", "Error removing favorite article", e)
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,9 @@ moshi = "1.15.2"
 #COIL
 coil = "2.7.0"
 
+#ROOM
+room = "2.8.4"
+
 #PLUGINS
 agp = "8.13.0"
 kotlin = "2.2.20"
@@ -70,6 +73,11 @@ moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-code
 
 # COIL
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+
+# ROOM
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 
 # TESTING
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
This PR contains the following changes:

Implemented Room database for favorite articles persistence  
- Added Room libraries and configuration to `libs.versions.toml` and build scripts 
- Created `AppRoomDatabase`, `ArticleDao`, and `RoomConstants` 
- Annotated `ArticleDbo` with Room entity definitions 
- Replaced in-memory mock implementation in `ArticleLocalDataSourceImpl` with actual DAO interactions 
- Refactored `save` and `remove` signatures across Data, Domain, and Gateway layers to return `Unit` instead of `Flow<Boolean>` 
- Updated `HomeViewModel` to handle suspend operations and exceptions 
- Configured `LocalModule` to provide `AppRoomDatabase` via Hilt