### PR TITLE
Feature/#44 update libaries

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
@@ -42,6 +42,7 @@ android {
 
     buildFeatures {
         compose = true
+        resValues = true
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
@@ -20,7 +18,7 @@ android {
         versionCode = AppConfig.versionCode
         versionName = AppConfig.versionName
         testInstrumentationRunner = AppConfig.testRunner
-        resValue("string", "app_name", AppConfig.applicationName)
+        manifestPlaceholders["appName"] = AppConfig.applicationName
     }
 
     buildTypes {
@@ -33,16 +31,8 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
-    }
-
     buildFeatures {
         compose = true
-        resValues = true
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appName}"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SplashScreen."

--- a/app/src/main/java/es/mobiledev/cpt/ui/screen/testNavigation/TestScreen.kt
+++ b/app/src/main/java/es/mobiledev/cpt/ui/screen/testNavigation/TestScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import es.mobiledev.commonandroid.R
 import es.mobiledev.commonandroid.ui.base.BaseScreen

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.android.library) apply false

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -28,11 +26,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/commonAndroid/build.gradle.kts
+++ b/commonAndroid/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 
@@ -30,12 +28,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/data/local/build.gradle.kts
+++ b/data/local/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
 }
 
@@ -31,11 +29,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
-    }
+}
+
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }
 
 dependencies {

--- a/data/local/schemas/es.mobiledev.data.local.AppRoomDatabase/1.json
+++ b/data/local/schemas/es.mobiledev.data.local.AppRoomDatabase/1.json
@@ -1,0 +1,55 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "7e999a56c4d5be1bb34f815b87b7abb8",
+    "entities": [
+      {
+        "tableName": "articles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `newsSite` TEXT NOT NULL, `addedAt` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newsSite",
+            "columnName": "newsSite",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7e999a56c4d5be1bb34f815b87b7abb8')"
+    ]
+  }
+}

--- a/data/remote/build.gradle.kts
+++ b/data/remote/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
@@ -31,11 +29,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/data/repository/build.gradle.kts
+++ b/data/repository/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
@@ -31,11 +29,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/data/session/build.gradle.kts
+++ b/data/session/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
@@ -31,11 +29,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/data/source/build.gradle.kts
+++ b/data/source/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -29,11 +27,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/domain/gateway/build.gradle.kts
+++ b/domain/gateway/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -29,11 +27,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/domain/model/build.gradle.kts
+++ b/domain/model/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -29,11 +27,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/domain/useCase/build.gradle.kts
+++ b/domain/useCase/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
@@ -31,11 +29,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 

--- a/feature/articledetail/build.gradle.kts
+++ b/feature/articledetail/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
@@ -32,11 +30,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
     buildFeatures {
         compose = true

--- a/feature/articledetail/src/main/java/es/mobiledev/feature/articledetail/screen/ArticleDetailScreen.kt
+++ b/feature/articledetail/src/main/java/es/mobiledev/feature/articledetail/screen/ArticleDetailScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import es.mobiledev.commonandroid.theme.CptTheme
 import es.mobiledev.commonandroid.ui.base.BaseScreen

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
@@ -32,11 +30,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
     buildFeatures {
         compose = true

--- a/feature/home/src/main/java/es/mobiledev/feature/home/screen/HomeScreen.kt
+++ b/feature/home/src/main/java/es/mobiledev/feature/home/screen/HomeScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import es.mobiledev.commonandroid.theme.CptTheme

--- a/feature/launcher/build.gradle.kts
+++ b/feature/launcher/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
@@ -33,13 +31,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
-    }
-
     buildFeatures {
         compose = true
     }

--- a/feature/launcher/src/main/java/es/mobiledev/feature/launcher/screen/LauncherScreen.kt
+++ b/feature/launcher/src/main/java/es/mobiledev/feature/launcher/screen/LauncherScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import es.mobiledev.commonandroid.theme.CptTheme
 import es.mobiledev.commonandroid.ui.base.BaseScreen

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,10 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
+android.r8.strictFullModeForKeepRules=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,5 +26,3 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
 android.r8.strictFullModeForKeepRules=false
-android.builtInKotlin=false
-android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
 #ANDROIDX CORE
-androidx-core = "1.17.0"
-androidx-core-splashscreen = "1.0.1"
-androidx-lifecycle = "2.9.4"
-androidx-activity-compose = "1.11.0"
+androidx-core = "1.18.0"
+androidx-core-splashscreen = "1.2.0"
+androidx-lifecycle = "2.10.0"
+androidx-activity-compose = "1.13.0"
 androidx-appcompat = "1.7.1"
 
 #KOTLIN
 logging-interceptor = "5.3.2"
-serialization-json = "1.7.2"
+serialization-json = "1.10.0"
 
 #COMPOSE
-compose-bom = "2025.10.00"
-navigation-compose = "2.9.5"
+compose-bom = "2026.03.01"
+navigation-compose = "2.9.7"
 
 #DI
 hilt = "2.59.2"
@@ -36,12 +36,12 @@ androidx-junit = "1.3.0"
 espresso-core = "3.7.0"
 
 #PREFERENCES
-datastore = "1.2.0"
+datastore = "1.2.1"
 
 #PLUGINS
 agp = "9.1.0"
 kotlin = "2.3.20"
-ktlint = "13.1.0"
+ktlint = "14.2.0"
 ksp = "2.3.6"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,10 +39,10 @@ espresso-core = "3.7.0"
 datastore = "1.2.0"
 
 #PLUGINS
-agp = "8.13.0"
+agp = "9.1.0"
 kotlin = "2.2.20"
 ktlint = "13.1.0"
-ksp = "2.2.0-2.0.2"
+ksp = "2.3.2"
 
 [libraries]
 # ANDROIDX CORE

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,8 @@ compose-bom = "2025.10.00"
 navigation-compose = "2.9.5"
 
 #DI
-hilt = "2.56.2"
-hilt-navigation = "1.2.0"
+hilt = "2.59.2"
+hilt-navigation = "1.3.0"
 
 #MOSHI
 moshi = "1.15.2"
@@ -40,9 +40,9 @@ datastore = "1.2.0"
 
 #PLUGINS
 agp = "9.1.0"
-kotlin = "2.2.20"
+kotlin = "2.3.20"
 ktlint = "13.1.0"
-ksp = "2.3.2"
+ksp = "2.3.6"
 
 [libraries]
 # ANDROIDX CORE
@@ -106,7 +106,6 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jun 19 18:52:46 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -1,9 +1,7 @@
 import es.mobiledev.buildsrc.AppConfig
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlinx.serialization)
 }
 
@@ -29,11 +27,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 }
 


### PR DESCRIPTION
**This PR contains the following changes:**

- Upgrade Gradle, AGP, and build configurations
- Upgrade Hilt, Kotlin, KSP, and related library versions.
- Remove redundant `kotlin-android` plugin and `jvmTarget` compiler options across modules.
- Update `hiltViewModel` imports to use `androidx.hilt.lifecycle.viewmodel.compose`.
- Refactor `app_name` to use `manifestPlaceholders` instead of `resValue`.
- Configure Room schema location in the `data:local` module and add initial database schema.
- Clean up `gradle.properties` by removing obsolete flags.
- Update library versions and Gradle JVM configurations